### PR TITLE
edits for reactGo PR

### DIFF
--- a/app/actions/topics.js
+++ b/app/actions/topics.js
@@ -128,7 +128,7 @@ export function decrementCount(id) {
         isIncrement: false
       })
       .then(() => dispatch(decrement(id)))
-      .catch(() => dispatch(createTopicFailure({id, error: 'Oops! Something went wrong and we couldn\'t add your vote'})));
+      .catch();//() => dispatch(createTopicFailure({id, error: 'Oops! Something went wrong and we couldn\'t add your vote'})));
   };
 }
 

--- a/server/db/mongo/controllers/topics.js
+++ b/server/db/mongo/controllers/topics.js
@@ -39,25 +39,76 @@ export function update(req, res) {
   const omitKeys = ['id', '_id', '_v', 'isIncrement', 'isFull'];
   const data = _.omit(req.body, omitKeys);
 
-  if (isFull) {
-    Topic.findOneAndUpdate(query, data, (err) => {
-      if (err) {
-        console.log('Error on save!');
-        return res.status(500).send('We failed to save for some reason');
+  new Promise(function(resolve, reject){//promise(find one Topic document)
+    try {
+      Topic.find(query, function(err, res){
+        if(err) reject(err);
+        let count = res.length;
+        if (count === 1)
+          resolve(res[0]);
+        else
+          reject("There were " + count + " documents matching query instead of 1 expected");
+      });
+    } catch (err) {
+      console.log("Topic.find() try/catch block error");
+    }
+  })//close promise(Topic.find)
+  
+  .then((res) => {//.then(validate)
+    return new Promise(function(resolve, reject){    
+      isIncrement ? res.count += 1 : res.count -= 1;
+        try{
+          res.validate({}, (err) => {
+            if(err){
+              console.log("Error validating: " + JSON.stringify(err));
+              reject(err);
+            }
+            else{
+              console.log("validated model in then: " + JSON.stringify(res));
+              resolve(res);
+            }
+          });
+        } catch (err){
+          console.log("validate try/catch threw error: " + JSON.stringify(err));
+        }
+    });//close promise
+  })//close .then(validate)
+  
+  .then((res) => {//now update the document
+    return new Promise(function(resolve, reject){
+      try{
+        if (isFull) {
+          Topic.update(query, data, (err) => {
+            if (err) {
+              console.log("Error on save!");
+              reject(err);
+            }
+            resolve("Updated successfully");
+          });
+        } else {
+          Topic.update(query, { $inc: { count: isIncrement ? 1 : -1 } }, (err) => {
+            if (err) {
+              console.log("Error on save!");
+              reject(err);
+            }
+            console.log("db.update result: ok");
+            resolve("Updated successfully");
+          });
+        }
+      } catch (err) {
+        console.log("update try catch threw error: " + JSON.stringify(err));
       }
-
-      return res.status(200).send('Updated successfully');
     });
-  } else {
-    Topic.findOneAndUpdate(query, { $inc: { count: isIncrement ? 1 : -1 } }, (err) => {
-      if (err) {
-        console.log('Error on save!');
-        return res.status(500).send('We failed to save for some reason');
-      }
-
-      return res.status(200).send('Updated successfully');
-    });
-  }
+  })//close .then(update)
+  
+  .then((res) => {
+    return resp.status(200).send(res);
+  })
+  
+  .catch((err) => {
+    console.log("Sorry, error in db update: " + JSON.stringify(err));
+    return resp.status(500).send('We failed to save for some reason');
+  });
 }
 
 /**


### PR DESCRIPTION
I was unhappy that the minimum count of the Topic model was not being enforced, and that Topic votes could become negative.

I split the update() controller for MongoDB into three promises:
1 - find the Topic to update and verify the query only found one document
2 - run .validate() against the document found
3 - if .validate() succeeds, update the document

The changes I made open a new problem: atomicity. I'm not sure what to do about this while still using MongoDB. Please let me know your thoughts on the matter.

Also please note that a failed validation will dispatch createTopicFailure() in app/actions/topics.js. The result is to remove the Topic from the list. In order to prevent that, I removed arguments to the .catch() clause of the makeTopicRequest() promise in decrementCount(). I'm creating another PR for that change. I think there should be a better approach to this.